### PR TITLE
add .CR3

### DIFF
--- a/DCIMautoupload.py
+++ b/DCIMautoupload.py
@@ -7,7 +7,7 @@ import itertools
 import pyexiv2 # apt install python3-py3exiv2
 from rclone_python import rclone # pip install rclone-python
 
-EXTENSIONS = [".JPG", ".RW2", ".CR2", ".CR3", ".ORF", ".ARW", ".DNF"] # TODO: from config
+EXTENSIONS = [".JPG", "HEIC", "HIF", ".RW2", ".CR2", ".CR3", ".ORF", ".ARW", ".DNF"] # TODO: from config
 REMOTE = "sciebo:DCIM/" # TODO: from config
 
 if __name__ == "__main__":

--- a/DCIMautoupload.py
+++ b/DCIMautoupload.py
@@ -7,7 +7,7 @@ import itertools
 import pyexiv2 # apt install python3-py3exiv2
 from rclone_python import rclone # pip install rclone-python
 
-EXTENSIONS = [".JPG", "HEIC", "HIF", ".RW2", ".CR2", ".CR3", ".ORF", ".ARW", ".DNF"] # TODO: from config
+EXTENSIONS = [".JPG", ".HEIC", ".HIF", ".RW2", ".CR2", ".CR3", ".ORF", ".ARW", ".DNF"] # TODO: from config
 REMOTE = "sciebo:DCIM/" # TODO: from config
 
 if __name__ == "__main__":

--- a/DCIMautoupload.py
+++ b/DCIMautoupload.py
@@ -7,7 +7,7 @@ import itertools
 import pyexiv2 # apt install python3-py3exiv2
 from rclone_python import rclone # pip install rclone-python
 
-EXTENSIONS = [".JPG", ".RW2", ".CR2", ".ORF", ".ARW", ".DNF"] # TODO: from config
+EXTENSIONS = [".JPG", ".RW2", ".CR2", ".CR3", ".ORF", ".ARW", ".DNF"] # TODO: from config
 REMOTE = "sciebo:DCIM/" # TODO: from config
 
 if __name__ == "__main__":


### PR DESCRIPTION
For newer Canon cameras, CR3 is the format used for RAWs.

HEIC & HIF are also used by many modern cameras as a replacement for jpegs.

I would also consider copying XMP files that are created for each RAW file by many professional cameras.
Each RAW file often includes a .XMP file with the same filename, containing additional metadata (like flags / star ratings).